### PR TITLE
Allow custom port and note Node 18 requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,5 @@
 # StressTest
+
+## Requirements
+
+This project uses the built-in `fetch` API. Node.js 18 or newer is required for this global API. If you need to support an older Node version, install `node-fetch` and import it explicitly.

--- a/index.js
+++ b/index.js
@@ -5,7 +5,7 @@ import timeout from "connect-timeout";
 
 const { POLICY_HANDLING_SERVICE: phs } = process.env;
 const app = express();
-const port = 27500;
+const port = process.env.PORT || 27500;
 // app.use(bodyParser.urlencoded({ extended: false }))
 // parse application/json
 app.use(bodyParser.json())


### PR DESCRIPTION
## Summary
- make server port configurable via `process.env.PORT`
- document Node 18+ requirement for built-in `fetch` API

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_686e3d8da6ac832fb63fe4364c0bd60b