### PR TITLE
Add basic tests and CI workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,15 @@
+name: Node.js CI
+
+on:
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: '20'
+      - run: npm install
+      - run: npm test

--- a/index.js
+++ b/index.js
@@ -6,6 +6,8 @@ import timeout from "connect-timeout";
 const { POLICY_HANDLING_SERVICE: phs } = process.env;
 const app = express();
 const port = 27500;
+const isTest = process.env.NODE_ENV === 'test';
+const delay = (ms) => (isTest ? 0 : ms);
 // app.use(bodyParser.urlencoded({ extended: false }))
 // parse application/json
 app.use(bodyParser.json())
@@ -35,12 +37,12 @@ app.post("/policy", (req, res, next) => {
   if (case3) {
     setTimeout(() => {
       res.status(400).json({status, street});
-    }, 3000);
+    }, delay(3000));
   } else {
     if (case2) {
       setTimeout(() => {
         res.status(429).json({status, street});
-      }, 3000);
+      }, delay(3000));
     } else {
       const policyNumber = `ED1000POLICY${nanoid()}`;
       const interval = setInterval(() => { console.count(policyNumber) }, 1000);
@@ -68,9 +70,9 @@ app.post("/policy", (req, res, next) => {
         if (callback_url) {
           setTimeout(() => {
             fetch(`${callback_url}`, options);
-          }, 3000);
+          }, delay(3000));
         }
-      }, 6000);
+      }, delay(6000));
     }
   }
 });
@@ -93,7 +95,7 @@ app.all("/cb5d8aa6-c9f4-4517-87d9-3a92a2fc1262", (req, res) => {
       size: policies.length
     });
     console.warn(`${FgGreen}End Callback: ${callbackAmount++} - ${policyCallback} Total:${policies.length}${Reset}`);
-  }, 7000);
+  }, delay(7000));
 });
 app.all("/callback/:processId", (req, res) => {
   const { processId } = req.params;
@@ -111,16 +113,24 @@ app.all("/callback/:processId", (req, res) => {
     if (body.policyNumber){
       setTimeout(()=> {
         fetch(`${phs}/policy/callback/${processId}`, options);
-      }, 3000);
+      }, delay(3000));
     } else {
      fetch(`https://27500-edmilsonsilv-stresstest-pu1oq4oaxpr.ws-eu116.gitpod.io/cb5d8aa6-c9f4-4517-87d9-3a92a2fc1262`, options);
     }
     setTimeout(()=> {
       fetch(`https://webhook.site/c74827f5-5199-48ac-b4ed-85993de1166f/${processId}`, options);
-    }, 3000);
+    }, delay(3000));
     res.status(200).json({ status: 200, success: true, message: "" });
-  }, 7000);
+  }, delay(7000));
 });
-app.listen(port, () => {
-  console.log(`EdCarrier app listening on port ${port}`);
-});
+if (!isTest) {
+  app.listen(port, () => {
+    console.log(`EdCarrier app listening on port ${port}`);
+  });
+}
+
+export function _resetPolicies() {
+  policies.length = 0;
+}
+
+export default app;

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "type": "module",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1",
+    "test": "NODE_ENV=test node --test",
     "start": "node index",
     "start:watch": "nodemon"
   },

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -1,0 +1,110 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import app, { _resetPolicies } from '../index.js';
+
+const startServer = () => {
+  const server = app.listen(0);
+  const port = server.address().port;
+  const url = `http://localhost:${port}`;
+  return { server, url };
+};
+
+const headers = { 'Content-Type': 'application/json' };
+
+// ensure NODE_ENV is test for immediate responses
+process.env.NODE_ENV = 'test';
+
+// helper to fetch JSON
+const jsonFetch = async (url, options) => {
+  const res = await fetch(url, options);
+  let body;
+  try { body = await res.json(); } catch { body = undefined; }
+  return { res, body };
+};
+
+test('POST /policy returns 200 when success', async () => {
+  _resetPolicies();
+  const { server, url } = startServer();
+  const body = { status: 'ok', street: 'Test' };
+  // force case1
+  const origRandom = Math.random;
+  Math.random = () => 0.2;
+  const { res, body: data } = await jsonFetch(`${url}/policy`, {
+    method: 'POST',
+    headers,
+    body: JSON.stringify(body)
+  });
+  Math.random = origRandom;
+  assert.equal(res.status, 200);
+  assert.ok(data.policyNumber);
+  server.close();
+});
+
+test('POST /policy returns 400 on case3', async () => {
+  const { server, url } = startServer();
+  const origRandom = Math.random;
+  Math.random = () => 0;
+  const { res } = await jsonFetch(`${url}/policy`, {
+    method: 'POST',
+    headers,
+    body: JSON.stringify({})
+  });
+  Math.random = origRandom;
+  assert.equal(res.status, 400);
+  server.close();
+});
+
+test('POST /policy returns 429 on case2', async () => {
+  const { server, url } = startServer();
+  const origRandom = Math.random;
+  Math.random = () => 0.99;
+  const { res } = await jsonFetch(`${url}/policy`, {
+    method: 'POST',
+    headers,
+    body: JSON.stringify({})
+  });
+  Math.random = origRandom;
+  assert.equal(res.status, 429);
+  server.close();
+});
+
+test('Callback endpoint returns data when policy exists', async () => {
+  _resetPolicies();
+  const { server, url } = startServer();
+  const origRandom = Math.random;
+  Math.random = () => 0.2; // case1 to create policy
+  const create = await jsonFetch(`${url}/policy`, { method: 'POST', headers, body: JSON.stringify({}) });
+  const policy = create.body.policyNumber;
+  Math.random = origRandom;
+  const { res, body: cbBody } = await jsonFetch(`${url}/cb5d8aa6-c9f4-4517-87d9-3a92a2fc1262`, {
+    method: 'POST',
+    headers,
+    body: JSON.stringify({ policyNumber: policy })
+  });
+  assert.equal(res.status, 200);
+  assert.equal(cbBody.policyNumber, policy);
+  server.close();
+});
+
+test('Callback endpoint returns 404 when policy missing', async () => {
+  const { server, url } = startServer();
+  const { res } = await jsonFetch(`${url}/cb5d8aa6-c9f4-4517-87d9-3a92a2fc1262`, {
+    method: 'POST',
+    headers,
+    body: JSON.stringify({ policyNumber: 'missing' })
+  });
+  assert.equal(res.status, 404);
+  server.close();
+});
+
+test('Process callback endpoint responds', async () => {
+  const { server, url } = startServer();
+  const { res, body } = await jsonFetch(`${url}/callback/test`, {
+    method: 'POST',
+    headers,
+    body: JSON.stringify({})
+  });
+  assert.equal(res.status, 200);
+  assert.equal(body.success, true);
+  server.close();
+});


### PR DESCRIPTION
## Summary
- modify Express app to export the app when used for tests
- add built-in node test suite covering all endpoints
- configure GitHub Actions workflow to run `npm test`
- update package.json test script for `node --test`

## Testing
- `npm test` *(fails: cannot find package 'express')*
- `npm install` *(fails to connect to registry)*

------
https://chatgpt.com/codex/tasks/task_e_686e3d8bba14832f98d0f392545289a5